### PR TITLE
Make SHA1s and SHA2s with ring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/target
+**/*.rs.bk

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,0 +1,81 @@
+[[package]]
+name = "cc"
+version = "1.0.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "hex"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "lazy_static"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libc"
+version = "0.2.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "ring"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "spin"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "swish"
+version = "0.1.0"
+dependencies = [
+ "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "untrusted"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[metadata]
+"checksum cc 1.0.29 (registry+https://github.com/rust-lang/crates.io-index)" = "4390a3b5f4f6bce9c1d0c00128379df433e53777fdd30e92f16a529332baec4e"
+"checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
+"checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
+"checksum libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "e962c7641008ac010fa60a7dfdc1712449f29c44ef2d4702394aea943ee75047"
+"checksum ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)" = "426bc186e3e95cac1e4a4be125a4aca7e84c2d616ffc02244eef36e2a60a093c"
+"checksum spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44363f6f51401c34e7be73db0db371c04705d35efbe9f7d6082e03a921a32c55"
+"checksum untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "55cd1f4b4e96b46aeb8d4855db4a7a9bd96eeeb5c6a1ab54593328761642ce2f"
+"checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
+"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "swish"
+version = "0.1.0"
+authors = ["Ryan James Spencer <spencer.ryanjames@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+ring = "0.14.6"
+hex = "0.3.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,8 @@ extern crate ring;
 use ring::digest;
 
 fn main() -> std::io::Result<()> {
-    // TODO Consider SHA256
+    // TODO Consider SHA256 instead
+    // This is just using the same as what git would do.
     let actual = digest::digest(&digest::SHA1, b"some line");
     let hex_digest = hex::encode(actual.as_ref());
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,14 @@
 extern crate hex;
 extern crate ring;
 
-use ring::{digest, test};
+use ring::digest;
 
 fn main() -> std::io::Result<()> {
-    let expected_hex = "09ca7e4eaa6e8ae9c7d261167129184883644d07dfba7cbfbc4c8a2e08360d5b";
-    let expected: Vec<u8> = test::from_hex(expected_hex).unwrap();
-    // TODO swap SHA256 out with SHA1 possibly for speed
-    // although SHA2 is probably fine (100ms difference in some benchmarks)
-    let actual = digest::digest(&digest::SHA256, b"hello, world");
-    let actual_hex = hex::encode(actual.as_ref());
-    assert_eq!(&expected, &actual.as_ref());
+    // TODO Consider SHA256
+    let actual = digest::digest(&digest::SHA1, b"some line");
+    let hex_digest = hex::encode(actual.as_ref());
 
-    println!("{:x?}", actual_hex);
+    println!("{:x?}", hex_digest);
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,18 @@
+extern crate hex;
+extern crate ring;
+
+use ring::{digest, test};
+
+fn main() -> std::io::Result<()> {
+    let expected_hex = "09ca7e4eaa6e8ae9c7d261167129184883644d07dfba7cbfbc4c8a2e08360d5b";
+    let expected: Vec<u8> = test::from_hex(expected_hex).unwrap();
+    // TODO swap SHA256 out with SHA1 possibly for speed
+    // although SHA2 is probably fine (100ms difference in some benchmarks)
+    let actual = digest::digest(&digest::SHA256, b"hello, world");
+    let actual_hex = hex::encode(actual.as_ref());
+    assert_eq!(&expected, &actual.as_ref());
+
+    println!("{:x?}", actual_hex);
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,11 +2,15 @@ extern crate hex;
 extern crate ring;
 
 use ring::digest;
+use std::io::{self, Read};
 
 fn main() -> std::io::Result<()> {
+    let mut buffer = String::new();
+    io::stdin().read_to_string(&mut buffer)?;
+
     // TODO Consider SHA256 instead
     // This is just using the same as what git would do.
-    let actual = digest::digest(&digest::SHA1, b"some line");
+    let actual = digest::digest(&digest::SHA1, buffer.as_ref());
     let hex_digest = hex::encode(actual.as_ref());
 
     println!("{:x?}", hex_digest);


### PR DESCRIPTION
There may be a speed difference here that is important, or may not be.

Ideally the aim of this repo is just to do a bunch of SHA1s on every line and then do a SHA1 across al lthe SHA1s (similar to the 20-byte SHA1 for packfiles in git).